### PR TITLE
fixing a bug with anyone claiming already claimed property

### DIFF
--- a/lib/lita/handlers/claims.rb
+++ b/lib/lita/handlers/claims.rb
@@ -49,7 +49,8 @@ module Lita
         property, environment = response.matches.first
         environment ||= 'default'
         environment_string = " (#{environment})" if environment != 'default'
-        if property && Claim.create(property, claimer, environment)
+        if property && !Claim.exists?(property, environment)
+          Claim.create(property, claimer, environment)
           reply = "#{property}#{environment_string} was claimed by #{claimer}."
         else
           existing_claimer = Claim.read(property, environment)


### PR DESCRIPTION
I've faced a bug where any user can claim already claimed property. And looking at code I can't figure out how this suppose to work.

Maybe Claim.create (aka redis.hset) should return false and not set a key? But in my case it's setting a key. Here is my Gemfile https://gist.github.com/7435735e953feade543c

This commit fixes this.
